### PR TITLE
Send without writing to file

### DIFF
--- a/chrome_extension/client/background.js
+++ b/chrome_extension/client/background.js
@@ -10,7 +10,8 @@ chrome.runtime.onInstalled.addListener(function (){
     });
 });
 
-const HOST = "http://localhost:8000/";
+//const HOST = "https://dallon.pythonanywhere.com/";
+const HOST = "http://localhost:8000/"
 
 function logErrorAtServer(err, alertIndicator){
     const baseUrl = HOST + "log-client-error";
@@ -57,7 +58,10 @@ function makeRequest(mapping, songName, songLang, pageUrl){
     fetch(baseUrl, options)
         .then(res=> {
             if (res.status == 200){
-                return res.blob();
+                ///let resp = JSON.parse(res);
+                ///for (var k in resp) console.log(k);
+                ///return resp["ankiDeck"]
+                return res.blob()
             } else {
                 throw Error("Server response to process lyrics from pageUrl: " + pageUrl + " has incorrect status code of : " + res.status + " with status text: " + res.statusText);
             }
@@ -67,7 +71,7 @@ function makeRequest(mapping, songName, songLang, pageUrl){
                 filename: songName + ".apkg"
                 //...
             }, function(e){
-                //don't need to do anything here
+                //TODO: should I revoke the object URL here? 
             });
         }).catch(err=>logErrorAtServer(err.toString(), true));
 };

--- a/chrome_extension/client/background.js
+++ b/chrome_extension/client/background.js
@@ -10,8 +10,8 @@ chrome.runtime.onInstalled.addListener(function (){
     });
 });
 
-//const HOST = "https://dallon.pythonanywhere.com/";
-const HOST = "http://localhost:8000/"
+const HOST = "https://dallon.pythonanywhere.com/";
+//const HOST = "http://localhost:8000/"
 
 function logErrorAtServer(err, alertIndicator){
     const baseUrl = HOST + "log-client-error";
@@ -58,19 +58,18 @@ function makeRequest(mapping, songName, songLang, pageUrl){
     fetch(baseUrl, options)
         .then(res=> {
             if (res.status == 200){
-                ///let resp = JSON.parse(res);
-                ///for (var k in resp) console.log(k);
-                ///return resp["ankiDeck"]
                 return res.blob()
             } else {
                 throw Error("Server response to process lyrics from pageUrl: " + pageUrl + " has incorrect status code of : " + res.status + " with status text: " + res.statusText);
             }
         }).then(blob=>{
+            let blobUrl = URL.createObjectURL(blob)
             chrome.downloads.download({
-                url: URL.createObjectURL(blob),
+                url: blobUrl,
                 filename: songName + ".apkg"
                 //...
             }, function(e){
+                URL.revokeObjectURL(blobUrl)
                 //TODO: should I revoke the object URL here? 
             });
         }).catch(err=>logErrorAtServer(err.toString(), true));

--- a/chrome_extension/client/getMapping.js
+++ b/chrome_extension/client/getMapping.js
@@ -67,8 +67,6 @@ function sleep(ms) {
                         return;
                     }
 
-
-
                 } else {
                     targetLang = foundTargetLang;
                 }
@@ -81,8 +79,8 @@ function sleep(ms) {
                     let song_ids = xa.map(a => a.getAttribute("class"));
                     let tr_ids = ya.map(a => a.getAttribute("class"));
                 
-                    if (song_lyrics.length != song_ids.length) alert("something's broken, dallon take a look");
-                    if (tr_lyrics.length != tr_ids.length) alert("something's broken, dallon take a look");
+                    //if (song_lyrics.length != song_ids.length) alert("something's broken, dallon take a look");
+                    //if (tr_lyrics.length != tr_ids.length) alert("something's broken, dallon take a look");
                 
                     let filtered_song_ids = song_ids.filter(a => a.includes("ll"));
                     let filtered_tr_ids = tr_ids.filter(a => a.includes("ll"));
@@ -145,8 +143,11 @@ function sleep(ms) {
                 });
             });
         } else {
-            //need to log url that was unable to process this request
-            sendLogMessage(new Error("Unable to parse both sets of lyrics from webpage " + window.location.href), true);
+            /* This state is most likely to occur when icon is clicked on song-info page instead of song-translation page*/
+            chrome.runtime.sendMessage({action: 'handleOnlyOneLangColumnDisplayed'}, function(response){
+                //do nothing here
+            });
+            return;
         }
     }
 })();

--- a/chrome_extension/client/manifest.json
+++ b/chrome_extension/client/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Song To Anki",
     "version": "1.0",
-    "description": "Find your favorite foreign-language song on lyricstranslate.com and generate an Anki space-repetition flashcard set to learn all the words!",
+    "description": "Find your favorite (foreign) song on lyricstranslate.com and generate an Anki space-repetition flashcard set to learn all the words!",
     "permissions": ["tabs", "activeTab", "declarativeContent", "storage", "<all_urls>", "downloads"],
     "background": {
         "scripts": ["background.js"],

--- a/chrome_extension/client/popup.html
+++ b/chrome_extension/client/popup.html
@@ -13,7 +13,7 @@
       <form style: id="form">
           <label for="songLangInput" name="textAboveInput">Which language are you learning?<br></label>
           <input type="text" id="songLangInput" name="songLangInput"><br><br>
-          <label id="chooseValidTargetLang">If neither of these is your target language, navigate to the translation page you want and try again.<br><br></label>
+          <label id="chooseValidTargetLang">If neither of the two language columns is your target language, then navigate to the translation page you want and try again.<br><br></label>
           <input type="submit" id="submit" value="Submit">
       </form>
 

--- a/chrome_extension/client/popup.js
+++ b/chrome_extension/client/popup.js
@@ -29,8 +29,13 @@ function getMapping(){
 }
 
 function handleInvalidTargetLangEntry(){
-    alert("The langauge you're learning isn't on this page. Please go to the right page and try again.")
+    alert("Hmm... it looks like the langauge you're learning isn't on this page. Please go to the right page and try again.")
     window.close();
+}
+
+function handleOnlyOneLangColumnDisplayed(){
+  alert("Hmm... it looks like this page is only showing one language. Please select a translation language below, then try again");
+  window.close();
 }
 
 submit.onclick = function(element) {
@@ -56,6 +61,9 @@ chrome.runtime.onMessage.addListener(
       }
       else if (request.action === "handleInvalidTargetLangEntry"){
         handleInvalidTargetLangEntry();
+      }
+      else if (request.action === "handleOnlyOneLangColumnDisplayed"){
+        handleOnlyOneLangColumnDisplayed();
       }
       else if (request.action === "readyWithError"){
         chrome.tabs.create({ url: "https://google.com" , active: false}, function(tab) {

--- a/chrome_extension/server/api.py
+++ b/chrome_extension/server/api.py
@@ -52,7 +52,7 @@ class Lyrics():
         self.lyrics = lyrics
         self.song_name = song_name
         self.song_lang = song_lang.lower()
-        self.lang_code = _get_lang_code(self.song_lang)
+        self.lang_code = langcodes.find(self.song_lang).language
         self.words_seen_in_this_deck = set()
         self.pkg = None
 
@@ -67,7 +67,7 @@ class Lyrics():
         self.anki_deck = _build_deck(self.notes, self.song_name)
         
     def build_anki_pkg(self):
-        self.pkg = Package(self.anki_deck).write_to_file()
+        self.pkg = Package(self.anki_deck).get_bytes()
     
     def build_cloze_deletion_sentence(self, lyric, translation):
         #cleanse of stop words and cloze words/phrases that aren't in my vocabulary (database? restAPI?)
@@ -113,10 +113,6 @@ class Lyrics():
 ##############################
 ## Helper Methods
 ##############################
-        
-def _get_lang_code(lang):
-    return langcodes.find(lang).language
-
 def _build_deck(notes, deckname):
     """Builds anki deck out of notes. Returns anki deck object"""
     deck = Deck(deck_id=23, name=deckname)

--- a/chrome_extension/server/api.py
+++ b/chrome_extension/server/api.py
@@ -1,21 +1,7 @@
-import sys
-import os
-import io
-import requests
-import uuid
-
 from genanki import Model
 from genanki import Note
 from genanki import Deck
 from customPackage import Package
-#from genanki import Package
-
-from time import sleep
-import random
-from datetime import datetime
-
-from typing import Set, List
-from enum import Enum
 
 from wordfreq import zipf_frequency
 import langcodes
@@ -68,7 +54,6 @@ class Lyrics():
         self.song_lang = song_lang.lower()
         self.lang_code = _get_lang_code(self.song_lang)
         self.words_seen_in_this_deck = set()
-        self.anki_deck_path = None
         self.pkg = None
 
     def build_anki_deck(self):
@@ -81,8 +66,8 @@ class Lyrics():
 
         self.anki_deck = _build_deck(self.notes, self.song_name)
         
-    def write_anki_deck_to_file(self):
-        self.anki_deck_path = self._wr_apkg(self.anki_deck, self.song_name)
+    def build_anki_pkg(self):
+        self.pkg = Package(self.anki_deck).write_to_file()
     
     def build_cloze_deletion_sentence(self, lyric, translation):
         #cleanse of stop words and cloze words/phrases that aren't in my vocabulary (database? restAPI?)
@@ -124,23 +109,6 @@ class Lyrics():
 
         return ' '.join(cloze_sentence), ' '.join(translation_tokens)
     
-    def cleanup(self):
-        try:
-            if self.anki_deck_path: os.remove(self.anki_deck_path)
-        except OSError:
-            pass
-    def _wr_apkg(self, deck, deckname):
-        """Writes deck to Anki apkg file
-        @params: anki deck object, deckname
-        @returns path to output dec
-    """
-        if not os.path.exists("decks"):
-            os.makedirs("decks")
-        fout = 'decks/{NAME}.apkg'.format(NAME=deckname)
-        pkg = Package(deck)
-        self.pkg = pkg.write_to_file(fout)
-        print('  {N} Notes WROTE: {APKG}'.format(N=len(deck.notes), APKG=fout))
-        return fout
 
 ##############################
 ## Helper Methods

--- a/chrome_extension/server/api.py
+++ b/chrome_extension/server/api.py
@@ -7,7 +7,8 @@ import uuid
 from genanki import Model
 from genanki import Note
 from genanki import Deck
-from genanki import Package
+from customPackage import Package
+#from genanki import Package
 
 from time import sleep
 import random
@@ -68,6 +69,7 @@ class Lyrics():
         self.lang_code = _get_lang_code(self.song_lang)
         self.words_seen_in_this_deck = set()
         self.anki_deck_path = None
+        self.pkg = None
 
     def build_anki_deck(self):
         self.notes = []
@@ -80,7 +82,7 @@ class Lyrics():
         self.anki_deck = _build_deck(self.notes, self.song_name)
         
     def write_anki_deck_to_file(self):
-        self.anki_deck_path = _wr_apkg(self.anki_deck, self.song_name)
+        self.anki_deck_path = self._wr_apkg(self.anki_deck, self.song_name)
     
     def build_cloze_deletion_sentence(self, lyric, translation):
         #cleanse of stop words and cloze words/phrases that aren't in my vocabulary (database? restAPI?)
@@ -127,6 +129,18 @@ class Lyrics():
             if self.anki_deck_path: os.remove(self.anki_deck_path)
         except OSError:
             pass
+    def _wr_apkg(self, deck, deckname):
+        """Writes deck to Anki apkg file
+        @params: anki deck object, deckname
+        @returns path to output dec
+    """
+        if not os.path.exists("decks"):
+            os.makedirs("decks")
+        fout = 'decks/{NAME}.apkg'.format(NAME=deckname)
+        pkg = Package(deck)
+        self.pkg = pkg.write_to_file(fout)
+        print('  {N} Notes WROTE: {APKG}'.format(N=len(deck.notes), APKG=fout))
+        return fout
 
 ##############################
 ## Helper Methods
@@ -141,19 +155,6 @@ def _build_deck(notes, deckname):
     for note in notes:
         deck.add_note(note)
     return deck
-
-def _wr_apkg(deck, deckname):
-    """Writes deck to Anki apkg file
-        @params: anki deck object, deckname
-        @returns path to output dec
-    """
-    if not os.path.exists("decks"):
-        os.makedirs("decks")
-    fout = 'decks/{NAME}.apkg'.format(NAME=deckname)
-    pkg = Package(deck)
-    pkg.write_to_file(fout)
-    print('  {N} Notes WROTE: {APKG}'.format(N=len(deck.notes), APKG=fout))
-    return fout
 
 if __name__ == "__main__":
     pass

--- a/chrome_extension/server/app.py
+++ b/chrome_extension/server/app.py
@@ -14,3 +14,6 @@ if __name__ == "__main__":
 #TODO
 #Need to validate incoming lyrics json obj to make sure nothing malicious
 #Can do this with JWT - have client sent token to verify that my client-side code constructed the object
+
+#Need to handle songs in multiple languages...eg danza kuduro is both portuguese and spanish
+#Optionally add romanization to non-roman scripts

--- a/chrome_extension/server/app.py
+++ b/chrome_extension/server/app.py
@@ -17,3 +17,4 @@ if __name__ == "__main__":
 
 #Need to handle songs in multiple languages...eg danza kuduro is both portuguese and spanish
 #Optionally add romanization to non-roman scripts
+#Also add options page to contact me with bugs?

--- a/chrome_extension/server/clientlogs.txt
+++ b/chrome_extension/server/clientlogs.txt
@@ -40,3 +40,35 @@ Error: Unable to parse songname from url https://lyricstranslate.com/en/divar-wa
 526	***	
 *** Exception on 29/09/2020 12:14:19 	***
 Error: Unable to parse songname from url https://lyricstranslate.com/en/divar-wall.html-0	***	
+*** Exception on 30/09/2020 20:42:14 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:43:26 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:46:30 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:47:10 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:50:19 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:51:29 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:54:16 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:55:22 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 20:59:44 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:35:31 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:36:10 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:36:36 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:41:07 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:45:30 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:47:38 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	
+*** Exception on 30/09/2020 21:48:12 	***
+Error: Server response to process lyrics from pageUrl: https://lyricstranslate.com/en/mood-humor.html has incorrect status code of : 400 with status text: BAD REQUEST	***	

--- a/chrome_extension/server/customPackage.py
+++ b/chrome_extension/server/customPackage.py
@@ -6,9 +6,9 @@ import tempfile
 import time
 import zipfile
 
+from genanki import Deck
 from custom_apkg_col import APKG_COL
 from custom_apkg_schema import APKG_SCHEMA
-from genanki import Deck
 
 class Package:
   def __init__(self, deck_or_decks=None, media_files=None):
@@ -19,7 +19,7 @@ class Package:
 
     self.media_files = media_files or []
 
-  def write_to_file(self):
+  def get_bytes(self):
     dbfile, dbfilename = tempfile.mkstemp()
     os.close(dbfile)
 
@@ -32,8 +32,6 @@ class Package:
     conn.commit()
     conn.close()
 
-
-    #TODO: store and return this object instead of writing it to disk
     f = io.BytesIO()
     with zipfile.ZipFile(f, 'w') as outzip:
         outzip.write(dbfilename, 'collection.anki2')
@@ -44,6 +42,7 @@ class Package:
 
         for idx, path in media_file_idx_to_path.items():
             outzip.write(path, str(idx))
+
     f.seek(0)
     return f
 
@@ -72,5 +71,5 @@ class Package:
     from anki.importing.apkg import AnkiPackageImporter
 
     tmpfilename = tempfile.NamedTemporaryFile(delete=False).name
-    self.write_to_file(tmpfilename)
+    self.get_bytes(tmpfilename)
     AnkiPackageImporter(mw.col, tmpfilename).run()

--- a/chrome_extension/server/customPackage.py
+++ b/chrome_extension/server/customPackage.py
@@ -5,7 +5,6 @@ import sqlite3
 import tempfile
 import time
 import zipfile
-import gzip
 
 from custom_apkg_col import APKG_COL
 from custom_apkg_schema import APKG_SCHEMA
@@ -20,7 +19,7 @@ class Package:
 
     self.media_files = media_files or []
 
-  def write_to_file(self, file):
+  def write_to_file(self):
     dbfile, dbfilename = tempfile.mkstemp()
     os.close(dbfile)
 

--- a/chrome_extension/server/customPackage.py
+++ b/chrome_extension/server/customPackage.py
@@ -1,0 +1,77 @@
+import json
+import os
+import io
+import sqlite3
+import tempfile
+import time
+import zipfile
+import gzip
+
+from custom_apkg_col import APKG_COL
+from custom_apkg_schema import APKG_SCHEMA
+from genanki import Deck
+
+class Package:
+  def __init__(self, deck_or_decks=None, media_files=None):
+    if isinstance(deck_or_decks, Deck):
+      self.decks = [deck_or_decks]
+    else:
+      self.decks = deck_or_decks
+
+    self.media_files = media_files or []
+
+  def write_to_file(self, file):
+    dbfile, dbfilename = tempfile.mkstemp()
+    os.close(dbfile)
+
+    conn = sqlite3.connect(dbfilename)
+    cursor = conn.cursor()
+
+    now_ts = int(time.time())
+    self.write_to_db(cursor, now_ts)
+
+    conn.commit()
+    conn.close()
+
+
+    #TODO: store and return this object instead of writing it to disk
+    f = io.BytesIO()
+    with zipfile.ZipFile(f, 'w') as outzip:
+        outzip.write(dbfilename, 'collection.anki2')
+
+        media_file_idx_to_path = dict(enumerate(self.media_files))
+        media_json = {idx: os.path.basename(path) for idx, path in media_file_idx_to_path.items()}
+        outzip.writestr('media', json.dumps(media_json))
+
+        for idx, path in media_file_idx_to_path.items():
+            outzip.write(path, str(idx))
+    f.seek(0)
+    return f
+
+  def write_to_db(self, cursor, now_ts):
+    cursor.executescript(APKG_SCHEMA)
+    cursor.executescript(APKG_COL)
+
+    for deck in self.decks:
+      deck.write_to_db(cursor, now_ts)
+
+  def write_to_collection_from_addon(self):
+    """
+    Write to local collection. *Only usable when running inside an Anki addon!* Only tested on Anki 2.1.
+    This writes to a temporary file and then calls the code that Anki uses to import packages.
+    Note: the caller may want to use mw.checkpoint and mw.reset as follows:
+      # creates a menu item called "Undo Add Notes From MyAddon" after this runs
+      mw.checkpoint('Add Notes From MyAddon')
+      # run import
+      my_package.write_to_collection_from_addon()
+      # refreshes main view so new deck is visible
+      mw.reset()
+    Tip: if your deck has the same name and ID as an existing deck, then the notes will get placed in that deck rather
+    than a new deck being created.
+    """
+    from aqt import mw  # main window
+    from anki.importing.apkg import AnkiPackageImporter
+
+    tmpfilename = tempfile.NamedTemporaryFile(delete=False).name
+    self.write_to_file(tmpfilename)
+    AnkiPackageImporter(mw.col, tmpfilename).run()

--- a/chrome_extension/server/custom_apkg_col.py
+++ b/chrome_extension/server/custom_apkg_col.py
@@ -1,0 +1,107 @@
+APKG_COL = r'''
+INSERT INTO col VALUES(
+    null,
+    1411124400,
+    1425279151694,
+    1425279151690,
+    11,
+    0,
+    0,
+    0,
+    '{
+        "activeDecks": [
+            1
+        ],
+        "addToCur": true,
+        "collapseTime": 1200,
+        "curDeck": 1,
+        "curModel": "1425279151691",
+        "dueCounts": true,
+        "estTimes": true,
+        "newBury": true,
+        "newSpread": 0,
+        "nextPos": 1,
+        "sortBackwards": false,
+        "sortType": "noteFld",
+        "timeLim": 0
+    }',
+    '{}',
+    '{
+        "1": {
+            "collapsed": false,
+            "conf": 1,
+            "desc": "",
+            "dyn": 0,
+            "extendNew": 10,
+            "extendRev": 50,
+            "id": 1,
+            "lrnToday": [
+                0,
+                0
+            ],
+            "mod": 1425279151,
+            "name": "Default",
+            "newToday": [
+                0,
+                0
+            ],
+            "revToday": [
+                0,
+                0
+            ],
+            "timeToday": [
+                0,
+                0
+            ],
+            "usn": 0
+        }
+    }',
+    '{
+        "1": {
+            "autoplay": true,
+            "id": 1,
+            "lapse": {
+                "delays": [
+                    10
+                ],
+                "leechAction": 0,
+                "leechFails": 8,
+                "minInt": 1,
+                "mult": 0
+            },
+            "maxTaken": 60,
+            "mod": 0,
+            "name": "Default",
+            "new": {
+                "bury": true,
+                "delays": [
+                    1,
+                    10
+                ],
+                "initialFactor": 2500,
+                "ints": [
+                    1,
+                    4,
+                    7
+                ],
+                "order": 1,
+                "perDay": 20,
+                "separate": true
+            },
+            "replayq": true,
+            "rev": {
+                "bury": true,
+                "ease4": 1.3,
+                "fuzz": 0.05,
+                "ivlFct": 1,
+                "maxIvl": 36500,
+                "minSpace": 1,
+                "perDay": 100
+            },
+            "timer": 0,
+            "usn": 0
+        }
+    }',
+    '{}'
+);
+'''

--- a/chrome_extension/server/custom_apkg_schema.py
+++ b/chrome_extension/server/custom_apkg_schema.py
@@ -1,0 +1,73 @@
+APKG_SCHEMA = '''
+CREATE TABLE col (
+    id              integer primary key,
+    crt             integer not null,
+    mod             integer not null,
+    scm             integer not null,
+    ver             integer not null,
+    dty             integer not null,
+    usn             integer not null,
+    ls              integer not null,
+    conf            text not null,
+    models          text not null,
+    decks           text not null,
+    dconf           text not null,
+    tags            text not null
+);
+CREATE TABLE notes (
+    id              integer primary key,   /* 0 */
+    guid            text not null,         /* 1 */
+    mid             integer not null,      /* 2 */
+    mod             integer not null,      /* 3 */
+    usn             integer not null,      /* 4 */
+    tags            text not null,         /* 5 */
+    flds            text not null,         /* 6 */
+    sfld            integer not null,      /* 7 */
+    csum            integer not null,      /* 8 */
+    flags           integer not null,      /* 9 */
+    data            text not null          /* 10 */
+);
+CREATE TABLE cards (
+    id              integer primary key,   /* 0 */
+    nid             integer not null,      /* 1 */
+    did             integer not null,      /* 2 */
+    ord             integer not null,      /* 3 */
+    mod             integer not null,      /* 4 */
+    usn             integer not null,      /* 5 */
+    type            integer not null,      /* 6 */
+    queue           integer not null,      /* 7 */
+    due             integer not null,      /* 8 */
+    ivl             integer not null,      /* 9 */
+    factor          integer not null,      /* 10 */
+    reps            integer not null,      /* 11 */
+    lapses          integer not null,      /* 12 */
+    left            integer not null,      /* 13 */
+    odue            integer not null,      /* 14 */
+    odid            integer not null,      /* 15 */
+    flags           integer not null,      /* 16 */
+    data            text not null          /* 17 */
+);
+CREATE TABLE revlog (
+    id              integer primary key,
+    cid             integer not null,
+    usn             integer not null,
+    ease            integer not null,
+    ivl             integer not null,
+    lastIvl         integer not null,
+    factor          integer not null,
+    time            integer not null,
+    type            integer not null
+);
+CREATE TABLE graves (
+    usn             integer not null,
+    oid             integer not null,
+    type            integer not null
+);
+CREATE INDEX ix_notes_usn on notes (usn);
+CREATE INDEX ix_cards_usn on cards (usn);
+CREATE INDEX ix_revlog_usn on revlog (usn);
+CREATE INDEX ix_cards_nid on cards (nid);
+CREATE INDEX ix_cards_sched on cards (did, queue, due);
+CREATE INDEX ix_revlog_cid on revlog (cid);
+CREATE INDEX ix_notes_csum on notes (csum);
+'''

--- a/chrome_extension/server/logs.txt
+++ b/chrome_extension/server/logs.txt
@@ -112,3 +112,37 @@ Can't find any language named ''	***
 'errorContext'	***	
 *** Exception on 29/09/2020 11:50:26 	***
 'errorContext'	***	
+*** Exception on 30/09/2020 20:33:57 	***
+	***	
+*** Exception on 30/09/2020 20:42:14 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:43:26 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:46:30 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:47:10 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:50:19 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:51:29 	***
+name 'self' is not defined	***	
+*** Exception on 30/09/2020 20:54:16 	***
+Object of type Package is not JSON serializable	***	
+*** Exception on 30/09/2020 20:55:22 	***
+a bytes-like object is required, not 'Package'	***	
+*** Exception on 30/09/2020 20:59:44 	***
+Object of type Package is not JSON serializable	***	
+*** Exception on 30/09/2020 21:35:31 	***
+'Request' object has no attribute 'Response'	***	
+*** Exception on 30/09/2020 21:36:10 	***
+__init__() got an unexpected keyword argument 'content_type'	***	
+*** Exception on 30/09/2020 21:36:36 	***
+__init__() takes 1 positional argument but 2 were given	***	
+*** Exception on 30/09/2020 21:41:07 	***
+The view function did not return a valid response. The return type must be a string, dict, tuple, Response instance, or WSGI callable, but it was a BytesIO.	***	
+*** Exception on 30/09/2020 21:45:30 	***
+ZipFile requires mode 'r', 'w', 'x', or 'a'	***	
+*** Exception on 30/09/2020 21:47:38 	***
+write() takes 2 positional arguments but 3 were given	***	
+*** Exception on 30/09/2020 21:48:12 	***
+memoryview: a bytes-like object is required, not 'str'	***	

--- a/chrome_extension/server/routes.py
+++ b/chrome_extension/server/routes.py
@@ -1,8 +1,10 @@
 from datetime import datetime
-from flask import jsonify, request, send_from_directory
+from flask import Flask, jsonify, request, send_from_directory, send_file, make_response
 import json
 from api import Lyrics
 from sendgridAPI import send_email
+from io import BytesIO
+import requests
 
 LYRICS_TRANSLATE = 'lyricstranslate.com'
 
@@ -22,7 +24,12 @@ def configure_routes(app):
             lyrics.build_anki_deck()
             lyrics.write_anki_deck_to_file()
 
-            response = send_from_directory(directory='.', filename=lyrics.anki_deck_path)
+            response = send_file(
+                            lyrics.pkg,
+                            mimetype='application/apkg',
+                            as_attachment=True,
+                            attachment_filename=lyrics.song_name + ".apkg")
+
             lyrics.cleanup()
             return response
 

--- a/chrome_extension/server/routes.py
+++ b/chrome_extension/server/routes.py
@@ -1,10 +1,8 @@
 from datetime import datetime
-from flask import Flask, jsonify, request, send_from_directory, send_file, make_response
+from flask import jsonify, request, send_from_directory, send_file
 import json
 from api import Lyrics
 from sendgridAPI import send_email
-from io import BytesIO
-import requests
 
 LYRICS_TRANSLATE = 'lyricstranslate.com'
 

--- a/chrome_extension/server/routes.py
+++ b/chrome_extension/server/routes.py
@@ -22,19 +22,16 @@ def configure_routes(app):
 
             lyrics = Lyrics(lyrics, song_name, song_lang)
             lyrics.build_anki_deck()
-            lyrics.write_anki_deck_to_file()
+            lyrics.build_anki_pkg()
 
-            response = send_file(
+            return send_file(
                             lyrics.pkg,
                             mimetype='application/apkg',
                             as_attachment=True,
                             attachment_filename=lyrics.song_name + ".apkg")
 
-            lyrics.cleanup()
-            return response
-
         except Exception as ex:
-            contentMsg = get_error_content_message(request, ex)
+            contentMsg = build_error_content_message(request, ex)
             subjectMsg = "server side exception"
             send_email(subjectMsg, contentMsg)
             log_server_exception(ex)
@@ -50,14 +47,14 @@ def configure_routes(app):
             log_client_exception(errorContext)
 
             if sendAlertIndicator:
-                contentMsg = get_error_content_message(request, errorContext)
+                contentMsg = build_error_content_message(request, errorContext)
                 subjectMsg = "client side exception"
                 send_email(subjectMsg, contentMsg)
             
             return json_success({"emailSent": sendAlertIndicator})
 
         except Exception as ex:
-            contentMsg = get_error_content_message(request, ex)
+            contentMsg = build_error_content_message(request, ex)
             subjectMsg = "server side exception while logging exception from client"
             send_email(subjectMsg, contentMsg)
             log_server_exception(ex)
@@ -100,5 +97,5 @@ def log_client_exception(exc):
         file.write(exc)
         file.write(end_line)
 
-def get_error_content_message(req, ex):
+def build_error_content_message(req, ex):
     return "Input object is:\n {} \nand exception is\n {}".format(str(req.get_json()), str(ex))


### PR DESCRIPTION
Instead of writing an anki package to disk and then reading it back into memory as a bytes object, this change allows us to deal with the bytes object directly after generating the package, thus avoiding the need to write to disk.

Also added user alerting in case page only has one lyrics column, instead of both. This is better than posting a client-error to server because, in as many cases as I've seen, the issue is user error (corrected by instructions in alert), not a code error.